### PR TITLE
Fixed #2. Use vid_renderer as initial value for currentrenderer

### DIFF
--- a/src/posix/sdl/hardware.cpp
+++ b/src/posix/sdl/hardware.cpp
@@ -111,7 +111,7 @@ void I_InitGraphics ()
 	val.Bool = !!Args->CheckParm ("-devparm");
 	ticker.SetGenericRepDefault (val, CVAR_Bool);
 	
-	//currentrenderer = vid_renderer;
+	currentrenderer = vid_renderer;
 	if (currentrenderer==1) Video = new SDLGLVideo(0);
 	else Video = new SDLVideo (0);
 	
@@ -130,7 +130,7 @@ static void I_DeleteRenderer()
 
 void I_CreateRenderer()
 {
-	//currentrenderer = vid_renderer;
+	currentrenderer = vid_renderer;
 	if (Renderer == NULL)
 	{
 		Renderer = gl_CreateInterface();


### PR DESCRIPTION
The default value of vid_renderer is already set to 1, so we shall use that value when initializing renderer. Since currentrenderer never gets initialized otherwise, it well be initialized to zero, which is the non-existent software renderer.
